### PR TITLE
[Full Audit] Swedish Translations

### DIFF
--- a/sv/commands.json
+++ b/sv/commands.json
@@ -39,17 +39,17 @@
     },
 
     "avatar": {
-        "description": "Få en URL till en användares avatar.",
+        "description": "Få en URL till en användares profilbild.",
         "examples": ["avatar @Griefs#9476"],
         "args": {
             "user": {
-                "prompt": "Vems avatar skulle du vilja få?",
+                "prompt": "Vems profilbild skulle du vilja få?",
                 "label": "{lang:words.user}"
             }
         },
         "title": {
-            "valid": "Här är avataren för {0}. [[URL]]({0}).",
-            "invalid": "{0} har inte en avatar."
+            "valid": "Här är profilbilden för {0}. [[URL]]({0}).",
+            "invalid": "{0} har ingen profilbild."
         }
     },
     "birb": {
@@ -59,9 +59,9 @@
         "title": "🐱 Här är din kattbild!"
     },
     "corona": {
-        "none": "Landet kunde inte hittas eller så har den inte några fall.",
-        "nostats": "COVID-19-statistik är otilgängligt för tillfället.",
-        "nocountry": "Kunde inte få någon data för det landet.",
+        "none": "Landet kunde inte hittas eller så finns inga fall där.",
+        "nostats": "COVID-19-statistik är otilgänglig för tillfället.",
+        "nocountry": "Kunde inte hitta någon data för det landet.",
         "title": "Fall i {0}",
         "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {0} sen.",
         "titles": {
@@ -101,7 +101,7 @@
         "title": "🦊 Här är din rävbild!"
     },
     "fursuit": {
-        "title": "🐾 Här är din pälskostymsbild!"
+        "title": "🐾 Här är din pälsdräktsbild!"
     },
     "lenny": {},
     "owoify": {},
@@ -111,13 +111,13 @@
     },
     "vote-out": {},
     "daily": {
-        "success": "{:check:} Du har lagit beslag på din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
-        "failed": "Hoppsan! Det verkar som du redan har beslagit dina dagliga poäng. Återkom efter {0}.\n"
+        "success": "{:check:} Du har tagit emot din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
+        "failed": "Hoppsan! Det verkar som du redan har tagit emot dina dagliga poäng. Återkom efter {0}.\n"
     },
     "donate": {
         "success": "{:check:} Du donerade **{0}** poäng till {1}.",
         "self": "Du kan inte donera till dig själv, pälsboll.",
-        "bot": "Du kan inte donera till robotar, dumbom."
+        "bot": "Du kan inte donera till bottar, dumbom."
     },
     "leaderboard": {
         "title": "Placering",
@@ -152,7 +152,7 @@
         }
     },
     "vote": {
-        "info": "Du kan rösta på roboten [här]({0})",
+        "info": "Du kan rösta på botten [här]({0})",
         "perks": "2x-poängsbonus\nKortare NSFW-väntetider\nRäcker upp till 12 timmar",
         "voted": "Du har redan röstat. Du kan rösta igen [här]({0}) om 12 timmar.",
         "titles": {
@@ -211,7 +211,7 @@
         "current": "Spelar nu upp [{0}]({1})\n{2}"
     },
     "queue": {
-        "description": "Totalt {0} sånger\nTotalt {1} i längd\n{lang:commands.queue.loop.{2}}\n{lang:commands.queue.looptrack.{3}}",
+        "description": "Totalt {0} låtar\nTotalt {1} i längd\n{lang:commands.queue.loop.{2}}\n{lang:commands.queue.looptrack.{3}}",
         "loop": {
             "enabled": "✅ Låtupprepning påslagen",
             "disabled": "❌ Låtupprepning avslagen"
@@ -255,7 +255,7 @@
         "title": [
             "Jag slår vad om att den här killen har en söt rumpa.",
             "Här är elitporren du efterfrågade:",
-            "Den här killen ser mer mumsigare ut en mig själv.",
+            "Den här killen ser mer mumsigare ut än mig själv.",
             "***JAG*** är större än sådär, och jag är bara en tass.",
             "Söt fluffare, va?"
         ]
@@ -338,11 +338,11 @@
         "title": "{0} - {1} kompatibla! <:TFRBlepSmirk:655517665900625932>"
     },
     "language": {
-        "info": "Det nuvarande robotspråket är **{0}**.",
+        "info": "Det nuvarande botspråket är **{0}**.",
         "invalid": "`{0}` är inte ett giltigt språk.\nAnvänd {1}help \"settings language\" för hela listan av tillgängliga språk.",
         "success": {
-            "normal": "Satte framgångsrikt robotspråket till **{0}**.",
-            "default": "Satte framgångsrikt robotspråket till `default` (**{0}**)."
+            "normal": "Satte framgångsrikt botspråket till **{0}**.",
+            "default": "Satte framgångsrikt botspråket till `default` (**{0}**)."
         }
     },
     "levelup-channel": {
@@ -404,7 +404,7 @@
     },
     "about": {
         "title": "Om {0}",
-        "description": "{0} är den snabbast växande furry-, nytto- och moderation-roboten på Discord och hjälper till med över {1} servrar.",
+        "description": "{0} är den snabbast växande furry-, nytto- och moderation-botten på Discord och hjälper till med över {1} servrar.",
         "info": "{0} kan läggas till din server genom att använda \"{1}invite\"",
         "meettheteam": "Möt teamet",
         "specialthanks": "Speciellt tack"

--- a/sv/commands.json
+++ b/sv/commands.json
@@ -1,0 +1,451 @@
+{
+    "globals": {
+        "music": {
+            "noplayer": "Det finns inte någon aktiv uppspelning inom den här servern.",
+            "novc": "Du måste vara i en röstkanal för att använda det här kommandot!",
+            "active": "Jag spelar för tillfället musik i en annan röstkanal.",
+            "emptyqueue": "Kön är tom."
+        },
+        "reddit": {
+            "image": "Kan du inte se bilden? [Klicka mig]({0}).",
+            "video": "[Klicka mig för att se videon]({0})",
+            "error": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas."
+        },
+        "points": {
+            "notenough": "Hoppsan! Det verkar som du inte har nog med poäng för att göra det där."
+        }
+    },
+    "8ball": {
+        "question": "Fråga",
+        "answer": "Svar",
+        "list": [
+            "Ja",
+            "Nej",
+            "Kanske",
+            "Fråga igen",
+            "Ibland",
+            "Okej",
+            "NEJ FÖR I HELVETE",
+            "JA FÖR FAN",
+            "nej nej nej",
+            "Det där är ganska bögigt...men visst",
+            "Ultrabögigt",
+            "Jag har ingen jävla aning",
+            "Är det inte självklart?",
+            "Beror på vädret",
+            "Så sant som att månen är gjord av ost",
+            "Nästan garanterat"
+        ]
+    },
+
+    "avatar": {
+        "description": "Få en URL till en användares avatar.",
+        "examples": ["avatar @Griefs#9476"],
+        "args": {
+            "user": {
+                "prompt": "Vems avatar skulle du vilja få?",
+                "label": "{lang:words.user}"
+            }
+        },
+        "title": {
+            "valid": "Här är avataren för {0}. [[URL]]({0}).",
+            "invalid": "{0} har inte en avatar."
+        }
+    },
+    "birb": {
+        "title": "🦜 Här är din fågelbild!"
+    },
+    "cat": {
+        "title": "🐱 Här är din kattbild!"
+    },
+    "corona": {
+        "none": "Landet kunde inte hittas eller så har den inte några fall.",
+        "nostats": "COVID-19-statistik är otilgängligt för tillfället.",
+        "nocountry": "Kunde inte få någon data för det landet.",
+        "title": "Fall i {0}",
+        "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {0} sen.",
+        "titles": {
+            "cases": "Fall",
+            "deaths": "Dödsfall",
+            "infected": "Insjuknade",
+            "cured": "Friskförklarade",
+            "tests": "Tester",
+            "donations": "Donationer"
+        },
+        "donations": "**Totala donationer**: £{0}\n**Totala donatorer**: {1} personer\nSnälla överväg att donera till NHS på JustGiving för att stödja folk i nöd i dessa prövande tider [här]({2} \"akut vädjan angående COVID-19\")",
+        "format": "**Totalt**: {0}\n**Idag**: {1}"
+    },
+    "e926": {},
+    "e6": {
+        "searching": "Söker {:loading:}",
+        "none": "Hittade inga resultat med dem angivna etiketterna.",
+        "download": "Ladda ner",
+        "video": "**[Det här inlägget har en video. För att se den, klicka här]({0})**",
+        "source": "Källa",
+        "postid": "Inläggets ID: {0}",
+        "error": "{0} återkom med ett fel.",
+        "full": {
+            "sources": "Källor: {0}",
+            "score": "Poäng: {0}"
+        },
+        "tags": {
+            "title": "Etiketter",
+            "artist": "Artister: ",
+            "copyright": "Upphovsrätt: ",
+            "character": "Karaktärer: ",
+            "general": "Annat: ",
+            "additional": "och {0} mer"
+        }
+    },
+    "fox": {
+        "title": "🦊 Här är din rävbild!"
+    },
+    "fursuit": {
+        "title": "🐾 Här är din pälskostymsbild!"
+    },
+    "lenny": {},
+    "owoify": {},
+    "proxy": {},
+    "shibe": {
+        "title": "🐶 Här är din shibabild!"
+    },
+    "vote-out": {},
+    "daily": {
+        "success": "{:check:} Du har lagit beslag på din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
+        "failed": "Hoppsan! Det verkar som du redan har beslagit dina dagliga poäng. Återkom efter {0}.\n"
+    },
+    "donate": {
+        "success": "{:check:} Du donerade **{0}** poäng till {1}.",
+        "self": "Du kan inte donera till dig själv, pälsboll.",
+        "bot": "Du kan inte donera till robotar, dumbom."
+    },
+    "leaderboard": {
+        "title": "Placering",
+        "info": "Du är **#{0}** på topplistan med **{1}** poäng!",
+        "topfirst": "{0}{1}. {2}\n> **{3}** poäng",
+        "top": "{1}. {2} med **{3}** poäng!",
+        "more": "**{0}** andra användare är just nu på topplistan.",
+        "to": "{0} till {1}",
+        "server": "Topp 10 användarna i servern",
+        "world": "Topp 10 i världen"
+    },
+    "lottery": {
+        "info": "{:check:} Jag har lagt till dig till lotteriet för {0} poäng.\n[Se till att gå med i Discordservern för att få reda på vem som vann i lotterikanalen.](https://discord.gg/Kc7gDBb)",
+        "error": "Hoppsan, det verkar som ett fel uppstod.",
+        "entered": "Du har redan gått med i lotteriet."
+    },
+    "points": {
+        "points": "**{0}** poäng.",
+        "placement": "**#{0}** på topplistan",
+        "user": "Poäng för {0}",
+        "self": "Dina poäng",
+        "bonus": {
+            "title": "Aktiva bonusar",
+            "none": {
+                "self": "Du har inte några bonusar\nAnvänd {0} för en gratis bonus.",
+                "user": "Den här användaren har inte några bonusar\nAnvänd {0} för en gratis bonus."
+            },
+            "voted": {
+                "self": "Du har röstat **(2x-bonus)**",
+                "user": "Den här anävndaren har röstat **(2x-bonus)**"
+            }
+        }
+    },
+    "vote": {
+        "info": "Du kan rösta på roboten [här]({0})",
+        "perks": "2x-poängsbonus\nKortare NSFW-väntetider\nRäcker upp till 12 timmar",
+        "voted": "Du har redan röstat. Du kan rösta igen [här]({0}) om 12 timmar.",
+        "titles": {
+            "perks": "Förmåner",
+            "vote": "Hur man röstar"
+        }
+    },
+    "purge": {},
+    "qotd": {},
+    "role": {
+        "roleabove": "Den här rollen är ovanför din roll och kan varken läggas till eller tas bort.",
+        "userabove": "{0} har en roll ovanför dig och kan inte redigeras.",
+        "cannot_edit": "Jag kan inte redigera rollerna på {0} eftersom hen är ovanför min roll",
+        "added": "{0} har lagts till {1}.",
+        "removed": "{0} har tagits bort från {1}."
+    },
+    "slowmode": {
+        "title": "{:check:} Satte väntetiden till {0}",
+        "error": "Discord återkom med ett fel."
+    },
+    "clear": {
+        "success": "Rensade {0} låtar."
+    },
+    "join": {
+        "novc": "Du måste vara i en röstkanal för att anväda det här kommandot!"
+    },
+    "loop": {
+        "enabled": "Upprepning har slagits på.",
+        "disabled": "Upprepning har slagits av."
+    },
+    "looptrack": {
+        "enabled": "Spårupprepning har slagits på.",
+        "disabled": "Spårupprepning har slagits av."
+    },
+    "lyrics": {
+        "none": "Ingen låttext hittades för den aktuella låten."
+    },
+    "pause": {
+        "paused": "Uppspelningen är pausad. \\>Återupptar.",
+        "playing": "Pausad."
+    },
+    "play": {
+        "nosong": "Jag kan inte hitta den låten.",
+        "added": {
+            "multiple": "Lade till {0} låtar till kön.",
+            "single": {
+                "queued": "Lade till {0} till kön: `Plats {1}`",
+                "playing": "Lade till {0} till kön: `Spelas upp nu`"
+            }
+        },
+        "playing": "Uppspelning är inte pausad.",
+        "paused": "Återupptagen."
+    },
+    "playing": {
+        "none": "Ingen låt spelas.",
+        "current": "Spelar nu upp [{0}]({1})\n{2}"
+    },
+    "queue": {
+        "description": "Totalt {0} sånger\nTotalt {1} i längd\n{lang:commands.queue.loop.{2}}\n{lang:commands.queue.looptrack.{3}}",
+        "loop": {
+            "enabled": "✅ Låtupprepning påslagen",
+            "disabled": "❌ Låtupprepning avslagen"
+        },
+        "looptrack": {
+            "enabled": "✅ Köupprepning påslagen",
+            "disabled": "❌ Köupprepning avslagen"
+        },
+        "current": "Spelar nu upp"
+    },
+    "remove": {
+        "none": "Det finns ingen låt på den platsen.",
+        "success": "Tog bort {0}."
+    },
+    "shuffle": {
+        "none": "Det finns ingen kö att blanda.",
+        "success": "Blandad!"
+    },
+    "skip": {
+        "none": "Ingen låt spelas upp.",
+        "success": "Hoppade över."
+    },
+    "bulge": {
+        "title": [
+            "OwO \\*märker din bula\\* vad är detTA!??!",
+            "Vilket fint paket du har där.",
+            "Ser liten ut. Får jag pröva på den?",
+            "owO",
+            "\\*leker med din bula-lula\\*",
+            "Min är större.",
+            "Ojsan. Den är så stor att jag kan se min spegelbild i den."
+        ]
+    },
+    "e621": {},
+    "hentai": {},
+    "hooman": {},
+    "meme": {},
+    "murrsuit": {},
+    "yaoi": {},
+    "yiff": {
+        "title": [
+            "Jag slår vad om att den här killen har en söt rumpa.",
+            "Här är elitporren du efterfrågade:",
+            "Den här killen ser mer mumsigare ut en mig själv.",
+            "***JAG*** är större än sådär, och jag är bara en tass.",
+            "Söt fluffare, va?"
+        ]
+    },
+    "boop": {
+        "title": [
+            "{0} boppar försiktigt {1} på hens våta nos.",
+            "{0} ger {1} en puss på nosen.",
+            "{0} hoppar på {1} och duttar hens nos.",
+            "{0} ger plötsligt {1} en smack på nosen med hens tass.",
+            "{1} får en överraskningsdutt på hens nos av {0} och hens tass."
+        ]
+    },
+    "cuddle": {
+        "title": [
+            "{0} hoppar på {1} och ger hen nära kramar.",
+            "{1} blir kastad in i en lång, kärleksful kram med {0}.",
+            "{1} ramlar efter att ha måttat en häftig omfamning från {0}.",
+            "{1} tappar balansen när {0} lyfter upp hen i en klaustrofobisk kram.",
+            "{0} tar tag i {1} och tvingar hen in i en omfamning.",
+            "{0} ligger ovanpå {1} medans de håller i varandra i en varsam kram."
+        ]
+    },
+    "flop": {
+        "title": [
+            "{0} faller direkt ner i famnen av {1} med ett högt fvooosh.",
+            "{1} får sin famn ockuperad av {0}. Den som hittar den får den, är det väl?",
+            "{0} hoppar på {1} och plattar till hen.",
+            "{1} blir klämd av {0} och hens feta arsel.",
+            "{0} gör sig själv bekväm och landar på {1}.",
+            "{0} faller som en fjäder på {1}.",
+            "{0} blir uttröttad och bestämmer sig för att ta sig en tupplur på {1}."
+        ]
+    },
+    "fuck": {},
+    "hold": {
+        "title": [
+            "{0} håller kärleksfullt i {1} i sin mjuka, varsamma famn.",
+            "{0} tar mjukt tag i {1} med sina fluffiga tassar.",
+            "{1} dras leende nära {0}."
+        ]
+    },
+    "howl": {
+        "title": [
+            "{0} hör hur andra ylar och börjar yla med.",
+            "{0} höjer sitt huvud och börjar yla mot dem andra djuren."
+        ]
+    },
+    "hug": {
+        "title": [
+            "{1} dras in i en lång, varm kram av {0}.",
+            "{0} ger en väldigt mjuk, hårig kram till {1}.",
+            "{1} känner den mjuka pälsen av {0} mot sitt bröst när hen dras in i en kram.",
+            "{1} känner pälsen av {0} mot sitt bröst när hen blir kärleksfullt intvingad i en försiktig omfamning.",
+            "{0} blir invingad i en lång kram av {1}."
+        ]
+    },
+    "kiss": {
+        "title": [
+            "{1} får en lång, våt kyss av {0}.",
+            "{0} hoppar på {1} och ger hen en stor puss i ansiktet.",
+            "{1} dras in i en mjuk puss av {0}.",
+            "{0} ger {1} en mjuk puss på kinden. Kan du försöka att inte rodna?"
+        ]
+    },
+    "lick": {
+        "title": [
+            "{1} får en våt, slemmig slick på ansiktet av {0}. Stygg hund.",
+            "{0} bestämmer sig för att blöta ner {1} och hens päls och slickar hen rakt i ansiktet.",
+            "{0} får sin varma, våta saliv över hela ansiktet av {1}."
+        ]
+    },
+    "propose": {
+        "title": [
+            "Ojsan. {0} går ner på knä och friar till {1}...Det gick snabbt! Vad säger du {1}?",
+            "{0} tar fram en liten ask från sin ficka och tar fram en ring för {1}. Den ser billig ut, så jag skulle säga nej! Vad säger du {1}?"
+        ]
+    },
+    "ship": {
+        "title": "{0} - {1} kompatibla! <:TFRBlepSmirk:655517665900625932>"
+    },
+    "language": {
+        "info": "Det nuvarande robotspråket är **{0}**.",
+        "invalid": "`{0}` är inte ett giltigt språk.\nAnvänd {1}help \"settings language\" för hela listan av tillgängliga språk.",
+        "success": {
+            "normal": "Satte framgångsrikt robotspråket till **{0}**.",
+            "default": "Satte framgångsrikt robotspråket till `default` (**{0}**)."
+        }
+    },
+    "levelup-channel": {
+        "info": "Den nuvarande nivåmeddelandekanalen är **{0}**.",
+        "none": "Ingen nivåmeddelandekanal har specificerats.",
+        "invalid": "`{0}` är inte en giltig kanal.",
+        "success": {
+            "normal": "Satte framgångsrikt nivåmeddelandekanalen till **{0}**.",
+            "none": "Satte framgångsrikt nivåmeddelandekanalen till `none`."
+        }
+    },
+    "levelups": {
+        "info": {
+            "on": "Nivåmeddelandena är **påslagna**.",
+            "off": "Nivåmeddelandena är **avslagna**."
+        },
+        "success": {
+            "on": "Slog framgångsrikt **på** nivåmeddelanden.",
+            "off": "Slog framgångsrikt **av** nivåmedelanden.",
+            "default": "Satte framgångsrikt nivåmeddelanden till `default` (**{0}**)."
+        }
+    },
+    "logs": {
+        "info": "Den nuvarande loggkanalen är **{0}**.",
+        "none": "Ingen loggkanal har specificerats.",
+        "invalid": "`{0}` är inte en giltig kanal.",
+        "success": {
+            "normal": "Satte framgångsrikt loggkanalen till **{0}**.",
+            "none": "Satte framgångsrikt loggkanalen till `none`."
+        }
+    },
+    "qotd-manager-role": {
+        "info": "Den nuvarande QoTD-underhållarrollen är **{0}**.",
+        "none": "Ingen QoTD-underhållarroll har specificerats.",
+        "invalid": "`{0}` är inte en giltig QoTD-underhållarroll.",
+        "success": {
+            "normal": "Satte framgångsrikt QoTD-underhållarrollen till **{0}**.",
+            "none": "Satte framgångsrikt QoTD-underhållarrollen till `none`."
+        }
+    },
+    "qotd-role": {
+        "info": "Den nuvarande QoTD-aviseringsrollen är **{0}**.",
+        "none": "Ingen QoTD-aviseringsroll har specificerats.",
+        "invalid": "`{0}` är inte en giltig QoTD-aviseringsroll.",
+        "success": {
+            "normal": "Satte framgångsrikt QoTD-aviseringsrollen till **{0}**.",
+            "none": "Satte framgångsrikt QoTD-aviseringsrollen till `none`."
+        }
+    },
+    "toggle-unknown-command-responses": {},
+    "welcome-channel": {
+        "info": "Den nuvarande välkommstkanalen är **{0}**.",
+        "none": "Ingen välkommstkanal har specificerats.",
+        "invalid": "`{0}` är inte en giltig kanal.",
+        "success": {
+            "normal": "Satte framgångsrikt välkommstkanalen till **{0}**.",
+            "none": "Satte framgångsrikt välkommstkanalen till `none`."
+        }
+    },
+    "about": {
+        "title": "Om {0}",
+        "description": "{0} är den snabbast växande furry-, nytto- och moderation-roboten på Discord och hjälper till med över {1} servrar.",
+        "info": "{0} kan läggas till din server genom att använda \"{1}invite\"",
+        "meettheteam": "Möt teamet",
+        "specialthanks": "Speciellt tack"
+    },
+    "create-invite": {
+        "title": "Framgång",
+        "description": "{:check:} Jag skapade framgångsrikt en inbjudan till {0}.",
+        "invite": "Inbjudninglänk",
+        "max": "Maxanvändningar",
+        "exp": "Går ut efter",
+        "temp": "Temporärt medlemskap",
+        "enabled": "På",
+        "disabled": "Av",
+        "unable": "Jag kan inte skapa en inbjudan till den här kanalen."
+    },
+    "history": {
+        "title": "Historik",
+        "none": "Jag kunde inte hitta meddelandet du letade efter :(\nMeddelandet kan ha raderats från mitt minne. I det fallet kommer jag inte kunna hitta det."
+    },
+    "invite": {
+        "title": {
+            "add": "Lägg till mig",
+            "support": "Stöd",
+            "donate": "Donera"
+        },
+        "bot": "Du kan lägga till roboten [här]({0})",
+        "support": "Om du behöver assistans känn dig välkommen att fråga oss om hjälp på vår supportserver.",
+        "patreon": "Om du skulle vilja stödja utvecklingen av {0} och få förmåner fundera på att donera här: {1} {:furry.fingergun:}"
+    },
+    "permissions": {
+        "total": "Alla behörigheter ({0})",
+        "user": "Dina behörigheter ({0})",
+        "info": "Namn: Hexadecimal"
+    },
+    "coinflip": {
+        "title": [
+            "⭐ Det är krona!",
+            "🌙 Det är klave!"
+        ]
+    },
+    "dice": {
+        "title": "🎲 Du rullade en {0}!"
+    }
+}

--- a/sv/commands.json
+++ b/sv/commands.json
@@ -1,451 +1,452 @@
 {
-    "globals": {
-        "music": {
-            "noplayer": "Det finns inte någon aktiv uppspelning inom den här servern.",
-            "novc": "Du måste vara i en röstkanal för att använda det här kommandot!",
-            "active": "Jag spelar för tillfället musik i en annan röstkanal.",
-            "emptyqueue": "Kön är tom."
-        },
-        "reddit": {
-            "image": "Kan du inte se bilden? [Klicka mig]({0}).",
-            "video": "[Klicka mig för att se videon]({0})",
-            "error": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas."
-        },
-        "points": {
-            "notenough": "Hoppsan! Det verkar som du inte har nog med poäng för att göra det där."
-        }
+  "globals": {
+    "music": {
+      "noplayer": "Det finns inte någon aktiv uppspelning inom den här servern.",
+      "novc": "Du måste vara i en röstkanal för att använda det här kommandot!",
+      "active": "Jag spelar för tillfället musik i en annan röstkanal.",
+      "emptyqueue": "Kön är tom."
     },
-    "8ball": {
-        "question": "Fråga",
-        "answer": "Svar",
-        "list": [
-            "Ja",
-            "Nej",
-            "Kanske",
-            "Fråga igen",
-            "Ibland",
-            "Okej",
-            "NEJ FÖR I HELVETE",
-            "JA FÖR FAN",
-            "nej nej nej",
-            "Det där är ganska bögigt...men visst",
-            "Ultrabögigt",
-            "Jag har ingen jävla aning",
-            "Är det inte självklart?",
-            "Beror på vädret",
-            "Så sant som att månen är gjord av ost",
-            "Nästan garanterat"
-        ]
-    },
-
-    "avatar": {
-        "description": "Få en URL till en användares profilbild.",
-        "examples": ["avatar @Griefs#9476"],
-        "args": {
-            "user": {
-                "prompt": "Vems profilbild skulle du vilja få?",
-                "label": "{lang:words.user}"
-            }
-        },
-        "title": {
-            "valid": "Här är profilbilden för {0}. [[URL]]({0}).",
-            "invalid": "{0} har ingen profilbild."
-        }
-    },
-    "birb": {
-        "title": "🦜 Här är din fågelbild!"
-    },
-    "cat": {
-        "title": "🐱 Här är din kattbild!"
-    },
-    "corona": {
-        "none": "Landet kunde inte hittas eller så finns inga fall där.",
-        "nostats": "COVID-19-statistik är otilgänglig för tillfället.",
-        "nocountry": "Kunde inte hitta någon data för det landet.",
-        "title": "Fall i {0}",
-        "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {0} sen.",
-        "titles": {
-            "cases": "Fall",
-            "deaths": "Dödsfall",
-            "infected": "Insjuknade",
-            "cured": "Friskförklarade",
-            "tests": "Tester",
-            "donations": "Donationer"
-        },
-        "donations": "**Totala donationer**: £{0}\n**Totala donatorer**: {1} personer\nSnälla överväg att donera till NHS på JustGiving för att stödja folk i nöd i dessa prövande tider [här]({2} \"akut vädjan angående COVID-19\")",
-        "format": "**Totalt**: {0}\n**Idag**: {1}"
-    },
-    "e926": {},
-    "e6": {
-        "searching": "Söker {:loading:}",
-        "none": "Hittade inga resultat med dem angivna etiketterna.",
-        "download": "Ladda ner",
-        "video": "**[Det här inlägget har en video. För att se den, klicka här]({0})**",
-        "source": "Källa",
-        "postid": "Inläggets ID: {0}",
-        "error": "{0} återkom med ett fel.",
-        "full": {
-            "sources": "Källor: {0}",
-            "score": "Poäng: {0}"
-        },
-        "tags": {
-            "title": "Etiketter",
-            "artist": "Artister: ",
-            "copyright": "Upphovsrätt: ",
-            "character": "Karaktärer: ",
-            "general": "Annat: ",
-            "additional": "och {0} mer"
-        }
-    },
-    "fox": {
-        "title": "🦊 Här är din rävbild!"
-    },
-    "fursuit": {
-        "title": "🐾 Här är din pälsdräktsbild!"
-    },
-    "lenny": {},
-    "owoify": {},
-    "proxy": {},
-    "shibe": {
-        "title": "🐶 Här är din shibabild!"
-    },
-    "vote-out": {},
-    "daily": {
-        "success": "{:check:} Du har tagit emot din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
-        "failed": "Hoppsan! Det verkar som du redan har tagit emot dina dagliga poäng. Återkom efter {0}.\n"
-    },
-    "donate": {
-        "success": "{:check:} Du donerade **{0}** poäng till {1}.",
-        "self": "Du kan inte donera till dig själv, pälsboll.",
-        "bot": "Du kan inte donera till bottar, dumbom."
-    },
-    "leaderboard": {
-        "title": "Placering",
-        "info": "Du är **#{0}** på topplistan med **{1}** poäng!",
-        "topfirst": "{0}{1}. {2}\n> **{3}** poäng",
-        "top": "{1}. {2} med **{3}** poäng!",
-        "more": "**{0}** andra användare är just nu på topplistan.",
-        "to": "{0} till {1}",
-        "server": "Topp 10 användarna i servern",
-        "world": "Topp 10 i världen"
-    },
-    "lottery": {
-        "info": "{:check:} Jag har lagt till dig till lotteriet för {0} poäng.\n[Se till att gå med i Discordservern för att få reda på vem som vann i lotterikanalen.](https://discord.gg/Kc7gDBb)",
-        "error": "Hoppsan, det verkar som ett fel uppstod.",
-        "entered": "Du har redan gått med i lotteriet."
+    "reddit": {
+      "image": "Kan du inte se bilden? [Klicka mig]({0}).",
+      "video": "[Klicka mig för att se videon]({0})",
+      "error": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas."
     },
     "points": {
-        "points": "**{0}** poäng.",
-        "placement": "**#{0}** på topplistan",
-        "user": "Poäng för {0}",
-        "self": "Dina poäng",
-        "bonus": {
-            "title": "Aktiva bonusar",
-            "none": {
-                "self": "Du har inte några bonusar\nAnvänd {0} för en gratis bonus.",
-                "user": "Den här användaren har inte några bonusar\nAnvänd {0} för en gratis bonus."
-            },
-            "voted": {
-                "self": "Du har röstat **(2x-bonus)**",
-                "user": "Den här anävndaren har röstat **(2x-bonus)**"
-            }
-        }
+      "notenough": "Hoppsan! Det verkar som du inte har nog med poäng för att göra det där."
+    }
+  },
+  "8ball": {
+    "question": "Fråga",
+    "answer": "Svar",
+    "list": [
+      "Ja",
+      "Nej",
+      "Kanske",
+      "Fråga igen",
+      "Ibland",
+      "Okej",
+      "NEJ FÖR I HELVETE",
+      "JA FÖR FAN",
+      "nej nej nej",
+      "Det där är ganska bögigt...men visst",
+      "Ultrabögigt",
+      "Jag har ingen jävla aning",
+      "Är det inte självklart?",
+      "Beror på vädret",
+      "Så sant som att månen är gjord av ost",
+      "Nästan garanterat"
+    ]
+  },
+  "avatar": {
+    "description": "Få en URL till en användares profilbild.",
+    "examples": [
+      "avatar @Griefs#9476"
+    ],
+    "args": {
+      "user": {
+        "prompt": "Vems profilbild skulle du vilja få?",
+        "label": "{lang:words.user}"
+      }
     },
-    "vote": {
-        "info": "Du kan rösta på botten [här]({0})",
-        "perks": "2x-poängsbonus\nKortare NSFW-väntetider\nRäcker upp till 12 timmar",
-        "voted": "Du har redan röstat. Du kan rösta igen [här]({0}) om 12 timmar.",
-        "titles": {
-            "perks": "Förmåner",
-            "vote": "Hur man röstar"
-        }
+    "title": {
+      "valid": "Här är profilbilden för {0}. [[URL]]({0}).",
+      "invalid": "{0} har ingen profilbild."
+    }
+  },
+  "birb": {
+    "title": "🦜 Här är din fågelbild!"
+  },
+  "cat": {
+    "title": "🐱 Här är din kattbild!"
+  },
+  "corona": {
+    "none": "Landet kunde inte hittas eller så finns inga fall där.",
+    "nostats": "COVID-19-statistik är otilgänglig för tillfället.",
+    "nocountry": "Kunde inte hitta någon data för det landet.",
+    "title": "Fall i {0}",
+    "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {0} sen.",
+    "titles": {
+      "cases": "Fall",
+      "deaths": "Dödsfall",
+      "infected": "Insjuknade",
+      "cured": "Friskförklarade",
+      "tests": "Tester",
+      "donations": "Donationer"
     },
-    "purge": {},
-    "qotd": {},
-    "role": {
-        "roleabove": "Den här rollen är ovanför din roll och kan varken läggas till eller tas bort.",
-        "userabove": "{0} har en roll ovanför dig och kan inte redigeras.",
-        "cannot_edit": "Jag kan inte redigera rollerna på {0} eftersom hen är ovanför min roll",
-        "added": "{0} har lagts till {1}.",
-        "removed": "{0} har tagits bort från {1}."
+    "donations": "**Totala donationer**: £{0}\n**Totala donatorer**: {1} personer\nSnälla överväg att donera till NHS på JustGiving för att stödja folk i nöd i dessa prövande tider [här]({2} \"akut vädjan angående COVID-19\")",
+    "format": "**Totalt**: {0}\n**Idag**: {1}"
+  },
+  "e926": {},
+  "e6": {
+    "searching": "Söker {:loading:}",
+    "none": "Hittade inga resultat med dem angivna etiketterna.",
+    "download": "Ladda ner",
+    "video": "**[Det här inlägget har en video. För att se den, klicka här]({0})**",
+    "source": "Källa",
+    "postid": "Inläggets ID: {0}",
+    "error": "{0} återkom med ett fel.",
+    "full": {
+      "sources": "Källor: {0}",
+      "score": "Poäng: {0}"
     },
-    "slowmode": {
-        "title": "{:check:} Satte väntetiden till {0}",
-        "error": "Discord återkom med ett fel."
+    "tags": {
+      "title": "Etiketter",
+      "artist": "Artister: ",
+      "copyright": "Upphovsrätt: ",
+      "character": "Karaktärer: ",
+      "general": "Annat: ",
+      "additional": "och {0} mer"
+    }
+  },
+  "fox": {
+    "title": "🦊 Här är din rävbild!"
+  },
+  "fursuit": {
+    "title": "🐾 Här är din pälsdräktsbild!"
+  },
+  "lenny": {},
+  "owoify": {},
+  "proxy": {},
+  "shibe": {
+    "title": "🐶 Här är din shibabild!"
+  },
+  "vote-out": {},
+  "daily": {
+    "success": "{:check:} Du har tagit emot din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
+    "failed": "Hoppsan! Det verkar som du redan har tagit emot dina dagliga poäng. Återkom efter {0}.\n"
+  },
+  "donate": {
+    "success": "{:check:} Du donerade **{0}** poäng till {1}.",
+    "self": "Du kan inte donera till dig själv, pälsboll.",
+    "bot": "Du kan inte donera till bottar, dumbom."
+  },
+  "leaderboard": {
+    "title": "Placering",
+    "info": "Du är **#{0}** på topplistan med **{1}** poäng!",
+    "topfirst": "{0}{1}. {2}\n> **{3}** poäng",
+    "top": "{1}. {2} med **{3}** poäng!",
+    "more": "**{0}** andra användare är just nu på topplistan.",
+    "to": "{0} till {1}",
+    "server": "Topp 10 användarna i servern",
+    "world": "Topp 10 i världen"
+  },
+  "lottery": {
+    "info": "{:check:} Jag har lagt till dig till lotteriet för {0} poäng.\n[Se till att gå med i Discordservern för att få reda på vem som vann i lotterikanalen.](https://discord.gg/Kc7gDBb)",
+    "error": "Hoppsan, det verkar som ett fel uppstod.",
+    "entered": "Du har redan gått med i lotteriet."
+  },
+  "points": {
+    "points": "**{0}** poäng.",
+    "placement": "**#{0}** på topplistan",
+    "user": "Poäng för {0}",
+    "self": "Dina poäng",
+    "bonus": {
+      "title": "Aktiva bonusar",
+      "none": {
+        "self": "Du har inte några bonusar\nAnvänd {0} för en gratis bonus.",
+        "user": "Den här användaren har inte några bonusar\nAnvänd {0} för en gratis bonus."
+      },
+      "voted": {
+        "self": "Du har röstat **(2x-bonus)**",
+        "user": "Den här anävndaren har röstat **(2x-bonus)**"
+      }
+    }
+  },
+  "vote": {
+    "info": "Du kan rösta på botten [här]({0})",
+    "perks": "2x-poängsbonus\nKortare NSFW-väntetider\nRäcker upp till 12 timmar",
+    "voted": "Du har redan röstat. Du kan rösta igen [här]({0}) om 12 timmar.",
+    "titles": {
+      "perks": "Förmåner",
+      "vote": "Hur man röstar"
+    }
+  },
+  "purge": {},
+  "qotd": {},
+  "role": {
+    "roleabove": "Den här rollen är ovanför din roll och kan varken läggas till eller tas bort.",
+    "userabove": "{0} har en roll ovanför dig och kan inte redigeras.",
+    "cannot_edit": "Jag kan inte redigera rollerna på {0} eftersom hen är ovanför min roll",
+    "added": "{0} har lagts till {1}.",
+    "removed": "{0} har tagits bort från {1}."
+  },
+  "slowmode": {
+    "title": "{:check:} Satte väntetiden till {0}",
+    "error": "Discord återkom med ett fel."
+  },
+  "clear": {
+    "success": "Rensade {0} låtar."
+  },
+  "join": {
+    "novc": "Du måste vara i en röstkanal för att anväda det här kommandot!"
+  },
+  "loop": {
+    "enabled": "Upprepning har slagits på.",
+    "disabled": "Upprepning har slagits av."
+  },
+  "looptrack": {
+    "enabled": "Spårupprepning har slagits på.",
+    "disabled": "Spårupprepning har slagits av."
+  },
+  "lyrics": {
+    "none": "Ingen låttext hittades för den aktuella låten."
+  },
+  "pause": {
+    "paused": "Uppspelningen är pausad. \\>Återupptar.",
+    "playing": "Pausad."
+  },
+  "play": {
+    "nosong": "Jag kan inte hitta den låten.",
+    "added": {
+      "multiple": "Lade till {0} låtar till kön.",
+      "single": {
+        "queued": "Lade till {0} till kön: `Plats {1}`",
+        "playing": "Lade till {0} till kön: `Spelas upp nu`"
+      }
     },
-    "clear": {
-        "success": "Rensade {0} låtar."
-    },
-    "join": {
-        "novc": "Du måste vara i en röstkanal för att anväda det här kommandot!"
-    },
+    "playing": "Uppspelning är inte pausad.",
+    "paused": "Återupptagen."
+  },
+  "playing": {
+    "none": "Ingen låt spelas.",
+    "current": "Spelar nu upp [{0}]({1})\n{2}"
+  },
+  "queue": {
+    "description": "Totalt {0} låtar\nTotalt {1} i längd\n{lang:commands.queue.loop.{2}}\n{lang:commands.queue.looptrack.{3}}",
     "loop": {
-        "enabled": "Upprepning har slagits på.",
-        "disabled": "Upprepning har slagits av."
+      "enabled": "✅ Låtupprepning påslagen",
+      "disabled": "❌ Låtupprepning avslagen"
     },
     "looptrack": {
-        "enabled": "Spårupprepning har slagits på.",
-        "disabled": "Spårupprepning har slagits av."
+      "enabled": "✅ Köupprepning påslagen",
+      "disabled": "❌ Köupprepning avslagen"
     },
-    "lyrics": {
-        "none": "Ingen låttext hittades för den aktuella låten."
-    },
-    "pause": {
-        "paused": "Uppspelningen är pausad. \\>Återupptar.",
-        "playing": "Pausad."
-    },
-    "play": {
-        "nosong": "Jag kan inte hitta den låten.",
-        "added": {
-            "multiple": "Lade till {0} låtar till kön.",
-            "single": {
-                "queued": "Lade till {0} till kön: `Plats {1}`",
-                "playing": "Lade till {0} till kön: `Spelas upp nu`"
-            }
-        },
-        "playing": "Uppspelning är inte pausad.",
-        "paused": "Återupptagen."
-    },
-    "playing": {
-        "none": "Ingen låt spelas.",
-        "current": "Spelar nu upp [{0}]({1})\n{2}"
-    },
-    "queue": {
-        "description": "Totalt {0} låtar\nTotalt {1} i längd\n{lang:commands.queue.loop.{2}}\n{lang:commands.queue.looptrack.{3}}",
-        "loop": {
-            "enabled": "✅ Låtupprepning påslagen",
-            "disabled": "❌ Låtupprepning avslagen"
-        },
-        "looptrack": {
-            "enabled": "✅ Köupprepning påslagen",
-            "disabled": "❌ Köupprepning avslagen"
-        },
-        "current": "Spelar nu upp"
-    },
-    "remove": {
-        "none": "Det finns ingen låt på den platsen.",
-        "success": "Tog bort {0}."
-    },
-    "shuffle": {
-        "none": "Det finns ingen kö att blanda.",
-        "success": "Blandad!"
-    },
-    "skip": {
-        "none": "Ingen låt spelas upp.",
-        "success": "Hoppade över."
-    },
-    "bulge": {
-        "title": [
-            "OwO \\*märker din bula\\* vad är detTA!??!",
-            "Vilket fint paket du har där.",
-            "Ser liten ut. Får jag pröva på den?",
-            "owO",
-            "\\*leker med din bula-lula\\*",
-            "Min är större.",
-            "Ojsan. Den är så stor att jag kan se min spegelbild i den."
-        ]
-    },
-    "e621": {},
-    "hentai": {},
-    "hooman": {},
-    "meme": {},
-    "murrsuit": {},
-    "yaoi": {},
-    "yiff": {
-        "title": [
-            "Jag slår vad om att den här killen har en söt rumpa.",
-            "Här är elitporren du efterfrågade:",
-            "Den här killen ser mer mumsigare ut än mig själv.",
-            "***JAG*** är större än sådär, och jag är bara en tass.",
-            "Söt fluffare, va?"
-        ]
-    },
-    "boop": {
-        "title": [
-            "{0} boppar försiktigt {1} på hens våta nos.",
-            "{0} ger {1} en puss på nosen.",
-            "{0} hoppar på {1} och duttar hens nos.",
-            "{0} ger plötsligt {1} en smack på nosen med hens tass.",
-            "{1} får en överraskningsdutt på hens nos av {0} och hens tass."
-        ]
-    },
-    "cuddle": {
-        "title": [
-            "{0} hoppar på {1} och ger hen nära kramar.",
-            "{1} blir kastad in i en lång, kärleksful kram med {0}.",
-            "{1} ramlar efter att ha måttat en häftig omfamning från {0}.",
-            "{1} tappar balansen när {0} lyfter upp hen i en klaustrofobisk kram.",
-            "{0} tar tag i {1} och tvingar hen in i en omfamning.",
-            "{0} ligger ovanpå {1} medans de håller i varandra i en varsam kram."
-        ]
-    },
-    "flop": {
-        "title": [
-            "{0} faller direkt ner i famnen av {1} med ett högt fvooosh.",
-            "{1} får sin famn ockuperad av {0}. Den som hittar den får den, är det väl?",
-            "{0} hoppar på {1} och plattar till hen.",
-            "{1} blir klämd av {0} och hens feta arsel.",
-            "{0} gör sig själv bekväm och landar på {1}.",
-            "{0} faller som en fjäder på {1}.",
-            "{0} blir uttröttad och bestämmer sig för att ta sig en tupplur på {1}."
-        ]
-    },
-    "fuck": {},
-    "hold": {
-        "title": [
-            "{0} håller kärleksfullt i {1} i sin mjuka, varsamma famn.",
-            "{0} tar mjukt tag i {1} med sina fluffiga tassar.",
-            "{1} dras leende nära {0}."
-        ]
-    },
-    "howl": {
-        "title": [
-            "{0} hör hur andra ylar och börjar yla med.",
-            "{0} höjer sitt huvud och börjar yla mot dem andra djuren."
-        ]
-    },
-    "hug": {
-        "title": [
-            "{1} dras in i en lång, varm kram av {0}.",
-            "{0} ger en väldigt mjuk, hårig kram till {1}.",
-            "{1} känner den mjuka pälsen av {0} mot sitt bröst när hen dras in i en kram.",
-            "{1} känner pälsen av {0} mot sitt bröst när hen blir kärleksfullt intvingad i en försiktig omfamning.",
-            "{0} blir invingad i en lång kram av {1}."
-        ]
-    },
-    "kiss": {
-        "title": [
-            "{1} får en lång, våt kyss av {0}.",
-            "{0} hoppar på {1} och ger hen en stor puss i ansiktet.",
-            "{1} dras in i en mjuk puss av {0}.",
-            "{0} ger {1} en mjuk puss på kinden. Kan du försöka att inte rodna?"
-        ]
-    },
-    "lick": {
-        "title": [
-            "{1} får en våt, slemmig slick på ansiktet av {0}. Stygg hund.",
-            "{0} bestämmer sig för att blöta ner {1} och hens päls och slickar hen rakt i ansiktet.",
-            "{0} får sin varma, våta saliv över hela ansiktet av {1}."
-        ]
-    },
-    "propose": {
-        "title": [
-            "Ojsan. {0} går ner på knä och friar till {1}...Det gick snabbt! Vad säger du {1}?",
-            "{0} tar fram en liten ask från sin ficka och tar fram en ring för {1}. Den ser billig ut, så jag skulle säga nej! Vad säger du {1}?"
-        ]
-    },
-    "ship": {
-        "title": "{0} - {1} kompatibla! <:TFRBlepSmirk:655517665900625932>"
-    },
-    "language": {
-        "info": "Det nuvarande botspråket är **{0}**.",
-        "invalid": "`{0}` är inte ett giltigt språk.\nAnvänd {1}help \"settings language\" för hela listan av tillgängliga språk.",
-        "success": {
-            "normal": "Satte framgångsrikt botspråket till **{0}**.",
-            "default": "Satte framgångsrikt botspråket till `default` (**{0}**)."
-        }
-    },
-    "levelup-channel": {
-        "info": "Den nuvarande nivåmeddelandekanalen är **{0}**.",
-        "none": "Ingen nivåmeddelandekanal har specificerats.",
-        "invalid": "`{0}` är inte en giltig kanal.",
-        "success": {
-            "normal": "Satte framgångsrikt nivåmeddelandekanalen till **{0}**.",
-            "none": "Satte framgångsrikt nivåmeddelandekanalen till `none`."
-        }
-    },
-    "levelups": {
-        "info": {
-            "on": "Nivåmeddelandena är **påslagna**.",
-            "off": "Nivåmeddelandena är **avslagna**."
-        },
-        "success": {
-            "on": "Slog framgångsrikt **på** nivåmeddelanden.",
-            "off": "Slog framgångsrikt **av** nivåmedelanden.",
-            "default": "Satte framgångsrikt nivåmeddelanden till `default` (**{0}**)."
-        }
-    },
-    "logs": {
-        "info": "Den nuvarande loggkanalen är **{0}**.",
-        "none": "Ingen loggkanal har specificerats.",
-        "invalid": "`{0}` är inte en giltig kanal.",
-        "success": {
-            "normal": "Satte framgångsrikt loggkanalen till **{0}**.",
-            "none": "Satte framgångsrikt loggkanalen till `none`."
-        }
-    },
-    "qotd-manager-role": {
-        "info": "Den nuvarande QoTD-underhållarrollen är **{0}**.",
-        "none": "Ingen QoTD-underhållarroll har specificerats.",
-        "invalid": "`{0}` är inte en giltig QoTD-underhållarroll.",
-        "success": {
-            "normal": "Satte framgångsrikt QoTD-underhållarrollen till **{0}**.",
-            "none": "Satte framgångsrikt QoTD-underhållarrollen till `none`."
-        }
-    },
-    "qotd-role": {
-        "info": "Den nuvarande QoTD-aviseringsrollen är **{0}**.",
-        "none": "Ingen QoTD-aviseringsroll har specificerats.",
-        "invalid": "`{0}` är inte en giltig QoTD-aviseringsroll.",
-        "success": {
-            "normal": "Satte framgångsrikt QoTD-aviseringsrollen till **{0}**.",
-            "none": "Satte framgångsrikt QoTD-aviseringsrollen till `none`."
-        }
-    },
-    "toggle-unknown-command-responses": {},
-    "welcome-channel": {
-        "info": "Den nuvarande välkommstkanalen är **{0}**.",
-        "none": "Ingen välkommstkanal har specificerats.",
-        "invalid": "`{0}` är inte en giltig kanal.",
-        "success": {
-            "normal": "Satte framgångsrikt välkommstkanalen till **{0}**.",
-            "none": "Satte framgångsrikt välkommstkanalen till `none`."
-        }
-    },
-    "about": {
-        "title": "Om {0}",
-        "description": "{0} är den snabbast växande furry-, nytto- och moderation-botten på Discord och hjälper till med över {1} servrar.",
-        "info": "{0} kan läggas till din server genom att använda \"{1}invite\"",
-        "meettheteam": "Möt teamet",
-        "specialthanks": "Speciellt tack"
-    },
-    "create-invite": {
-        "title": "Framgång",
-        "description": "{:check:} Jag skapade framgångsrikt en inbjudan till {0}.",
-        "invite": "Inbjudninglänk",
-        "max": "Maxanvändningar",
-        "exp": "Går ut efter",
-        "temp": "Temporärt medlemskap",
-        "enabled": "På",
-        "disabled": "Av",
-        "unable": "Jag kan inte skapa en inbjudan till den här kanalen."
-    },
-    "history": {
-        "title": "Historik",
-        "none": "Jag kunde inte hitta meddelandet du letade efter :(\nMeddelandet kan ha raderats från mitt minne. I det fallet kommer jag inte kunna hitta det."
-    },
-    "invite": {
-        "title": {
-            "add": "Lägg till mig",
-            "support": "Stöd",
-            "donate": "Donera"
-        },
-        "bot": "Du kan lägga till roboten [här]({0})",
-        "support": "Om du behöver assistans känn dig välkommen att fråga oss om hjälp på vår supportserver.",
-        "patreon": "Om du skulle vilja stödja utvecklingen av {0} och få förmåner fundera på att donera här: {1} {:furry.fingergun:}"
-    },
-    "permissions": {
-        "total": "Alla behörigheter ({0})",
-        "user": "Dina behörigheter ({0})",
-        "info": "Namn: Hexadecimal"
-    },
-    "coinflip": {
-        "title": [
-            "⭐ Det är krona!",
-            "🌙 Det är klave!"
-        ]
-    },
-    "dice": {
-        "title": "🎲 Du rullade en {0}!"
+    "current": "Spelar nu upp"
+  },
+  "remove": {
+    "none": "Det finns ingen låt på den platsen.",
+    "success": "Tog bort {0}."
+  },
+  "shuffle": {
+    "none": "Det finns ingen kö att blanda.",
+    "success": "Blandad!"
+  },
+  "skip": {
+    "none": "Ingen låt spelas upp.",
+    "success": "Hoppade över."
+  },
+  "bulge": {
+    "title": [
+      "OwO \\*märker din bula\\* vad är detTA!??!",
+      "Vilket fint paket du har där.",
+      "Ser liten ut. Får jag pröva på den?",
+      "owO",
+      "\\*leker med din bula-lula\\*",
+      "Min är större.",
+      "Ojsan. Den är så stor att jag kan se min spegelbild i den."
+    ]
+  },
+  "e621": {},
+  "hentai": {},
+  "hooman": {},
+  "meme": {},
+  "murrsuit": {},
+  "yaoi": {},
+  "yiff": {
+    "title": [
+      "Jag slår vad om att den här killen har en söt rumpa.",
+      "Här är elitporren du efterfrågade:",
+      "Den här killen ser mer mumsigare ut än mig själv.",
+      "***JAG*** är större än sådär, och jag är bara en tass.",
+      "Söt fluffare, va?"
+    ]
+  },
+  "boop": {
+    "title": [
+      "{0} boppar försiktigt {1} på hens våta nos.",
+      "{0} ger {1} en puss på nosen.",
+      "{0} hoppar på {1} och duttar hens nos.",
+      "{0} ger plötsligt {1} en smack på nosen med hens tass.",
+      "{1} får en överraskningsdutt på hens nos av {0} och hens tass."
+    ]
+  },
+  "cuddle": {
+    "title": [
+      "{0} hoppar på {1} och ger hen nära kramar.",
+      "{1} blir kastad in i en lång, kärleksful kram med {0}.",
+      "{1} ramlar efter att ha måttat en häftig omfamning från {0}.",
+      "{1} tappar balansen när {0} lyfter upp hen i en klaustrofobisk kram.",
+      "{0} tar tag i {1} och tvingar hen in i en omfamning.",
+      "{0} ligger ovanpå {1} medans de håller i varandra i en varsam kram."
+    ]
+  },
+  "flop": {
+    "title": [
+      "{0} faller direkt ner i famnen av {1} med ett högt fvooosh.",
+      "{1} får sin famn ockuperad av {0}. Den som hittar den får den, är det väl?",
+      "{0} hoppar på {1} och plattar till hen.",
+      "{1} blir klämd av {0} och hens feta arsel.",
+      "{0} gör sig själv bekväm och landar på {1}.",
+      "{0} faller som en fjäder på {1}.",
+      "{0} blir uttröttad och bestämmer sig för att ta sig en tupplur på {1}."
+    ]
+  },
+  "fuck": {},
+  "hold": {
+    "title": [
+      "{0} håller kärleksfullt i {1} i sin mjuka, varsamma famn.",
+      "{0} tar mjukt tag i {1} med sina fluffiga tassar.",
+      "{1} dras leende nära {0}."
+    ]
+  },
+  "howl": {
+    "title": [
+      "{0} hör hur andra ylar och börjar yla med.",
+      "{0} höjer sitt huvud och börjar yla mot dem andra djuren."
+    ]
+  },
+  "hug": {
+    "title": [
+      "{1} dras in i en lång, varm kram av {0}.",
+      "{0} ger en väldigt mjuk, hårig kram till {1}.",
+      "{1} känner den mjuka pälsen av {0} mot sitt bröst när hen dras in i en kram.",
+      "{1} känner pälsen av {0} mot sitt bröst när hen blir kärleksfullt intvingad i en försiktig omfamning.",
+      "{0} blir invingad i en lång kram av {1}."
+    ]
+  },
+  "kiss": {
+    "title": [
+      "{1} får en lång, våt kyss av {0}.",
+      "{0} hoppar på {1} och ger hen en stor puss i ansiktet.",
+      "{1} dras in i en mjuk puss av {0}.",
+      "{0} ger {1} en mjuk puss på kinden. Kan du försöka att inte rodna?"
+    ]
+  },
+  "lick": {
+    "title": [
+      "{1} får en våt, slemmig slick på ansiktet av {0}. Stygg hund.",
+      "{0} bestämmer sig för att blöta ner {1} och hens päls och slickar hen rakt i ansiktet.",
+      "{0} får sin varma, våta saliv över hela ansiktet av {1}."
+    ]
+  },
+  "propose": {
+    "title": [
+      "Ojsan. {0} går ner på knä och friar till {1}...Det gick snabbt! Vad säger du {1}?",
+      "{0} tar fram en liten ask från sin ficka och tar fram en ring för {1}. Den ser billig ut, så jag skulle säga nej! Vad säger du {1}?"
+    ]
+  },
+  "ship": {
+    "title": "{0} - {1} kompatibla! <:TFRBlepSmirk:655517665900625932>"
+  },
+  "language": {
+    "info": "Det nuvarande botspråket är **{0}**.",
+    "invalid": "`{0}` är inte ett giltigt språk.\nAnvänd {1}help \"settings language\" för hela listan av tillgängliga språk.",
+    "success": {
+      "normal": "Satte framgångsrikt botspråket till **{0}**.",
+      "default": "Satte framgångsrikt botspråket till `default` (**{0}**)."
     }
+  },
+  "levelup-channel": {
+    "info": "Den nuvarande nivåmeddelandekanalen är **{0}**.",
+    "none": "Ingen nivåmeddelandekanal har specificerats.",
+    "invalid": "`{0}` är inte en giltig kanal.",
+    "success": {
+      "normal": "Satte framgångsrikt nivåmeddelandekanalen till **{0}**.",
+      "none": "Satte framgångsrikt nivåmeddelandekanalen till `none`."
+    }
+  },
+  "levelups": {
+    "info": {
+      "on": "Nivåmeddelandena är **påslagna**.",
+      "off": "Nivåmeddelandena är **avslagna**."
+    },
+    "success": {
+      "on": "Slog framgångsrikt **på** nivåmeddelanden.",
+      "off": "Slog framgångsrikt **av** nivåmedelanden.",
+      "default": "Satte framgångsrikt nivåmeddelanden till `default` (**{0}**)."
+    }
+  },
+  "logs": {
+    "info": "Den nuvarande loggkanalen är **{0}**.",
+    "none": "Ingen loggkanal har specificerats.",
+    "invalid": "`{0}` är inte en giltig kanal.",
+    "success": {
+      "normal": "Satte framgångsrikt loggkanalen till **{0}**.",
+      "none": "Satte framgångsrikt loggkanalen till `none`."
+    }
+  },
+  "qotd-manager-role": {
+    "info": "Den nuvarande QoTD-underhållarrollen är **{0}**.",
+    "none": "Ingen QoTD-underhållarroll har specificerats.",
+    "invalid": "`{0}` är inte en giltig QoTD-underhållarroll.",
+    "success": {
+      "normal": "Satte framgångsrikt QoTD-underhållarrollen till **{0}**.",
+      "none": "Satte framgångsrikt QoTD-underhållarrollen till `none`."
+    }
+  },
+  "qotd-role": {
+    "info": "Den nuvarande QoTD-aviseringsrollen är **{0}**.",
+    "none": "Ingen QoTD-aviseringsroll har specificerats.",
+    "invalid": "`{0}` är inte en giltig QoTD-aviseringsroll.",
+    "success": {
+      "normal": "Satte framgångsrikt QoTD-aviseringsrollen till **{0}**.",
+      "none": "Satte framgångsrikt QoTD-aviseringsrollen till `none`."
+    }
+  },
+  "toggle-unknown-command-responses": {},
+  "welcome-channel": {
+    "info": "Den nuvarande välkommstkanalen är **{0}**.",
+    "none": "Ingen välkommstkanal har specificerats.",
+    "invalid": "`{0}` är inte en giltig kanal.",
+    "success": {
+      "normal": "Satte framgångsrikt välkommstkanalen till **{0}**.",
+      "none": "Satte framgångsrikt välkommstkanalen till `none`."
+    }
+  },
+  "about": {
+    "title": "Om {0}",
+    "description": "{0} är den snabbast växande furry-, nytto- och moderation-botten på Discord och hjälper till med över {1} servrar.",
+    "info": "{0} kan läggas till din server genom att använda \"{1}invite\"",
+    "meettheteam": "Möt teamet",
+    "specialthanks": "Speciellt tack"
+  },
+  "create-invite": {
+    "title": "Framgång",
+    "description": "{:check:} Jag skapade framgångsrikt en inbjudan till {0}.",
+    "invite": "Inbjudninglänk",
+    "max": "Maxanvändningar",
+    "exp": "Går ut efter",
+    "temp": "Temporärt medlemskap",
+    "enabled": "På",
+    "disabled": "Av",
+    "unable": "Jag kan inte skapa en inbjudan till den här kanalen."
+  },
+  "history": {
+    "title": "Historik",
+    "none": "Jag kunde inte hitta meddelandet du letade efter :(\nMeddelandet kan ha raderats från mitt minne. I det fallet kommer jag inte kunna hitta det."
+  },
+  "invite": {
+    "title": {
+      "add": "Lägg till mig",
+      "support": "Stöd",
+      "donate": "Donera"
+    },
+    "bot": "Du kan lägga till roboten [här]({0})",
+    "support": "Om du behöver assistans känn dig välkommen att fråga oss om hjälp på vår supportserver.",
+    "patreon": "Om du skulle vilja stödja utvecklingen av {0} och få förmåner fundera på att donera här: {1} {:furry.fingergun:}"
+  },
+  "permissions": {
+    "total": "Alla behörigheter ({0})",
+    "user": "Dina behörigheter ({0})",
+    "info": "Namn: Hexadecimal"
+  },
+  "coinflip": {
+    "title": [
+      "⭐ Det är krona!",
+      "🌙 Det är klave!"
+    ]
+  },
+  "dice": {
+    "title": "🎲 Du rullade en {0}!"
+  }
 }

--- a/sv/commands.json
+++ b/sv/commands.json
@@ -49,7 +49,7 @@
       }
     },
     "title": {
-      "valid": "Här är profilbilden för {0}. [[URL]]({0}).",
+      "valid": "Här är profilbilden för {0}. [[URL]]({1}).",
       "invalid": "{0} har ingen profilbild."
     }
   },
@@ -64,7 +64,7 @@
     "nostats": "COVID-19-statistik är otilgänglig för tillfället.",
     "nocountry": "Kunde inte hitta någon data för det landet.",
     "title": "Fall i {0}",
-    "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {0} sen.",
+    "info": "Här är fall av COVID-19 i {0}.\nSist uppdaterad för {1} sen.",
     "titles": {
       "cases": "Fall",
       "deaths": "Dödsfall",

--- a/sv/constraints.json
+++ b/sv/constraints.json
@@ -1,3 +1,0 @@
-{
-  "nsfw": "Det här kommandot kan bara användas i NSFW-kanaler."
-}

--- a/sv/constraints.json
+++ b/sv/constraints.json
@@ -1,0 +1,3 @@
+{
+  "nsfw": "Det här kommandot kan bara användas i NSFW-kanaler."
+}

--- a/sv/core.json
+++ b/sv/core.json
@@ -1,0 +1,32 @@
+{
+    "blocked": {
+        "guildOnly": "`{0}`-kommandot måste användas i en server.",
+        "premiumOnly": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
+        "supportServerOnly": "`{0}`-kommandot kan bara användas i supportservern. {:furry.really:}",
+        "hasOne": "Du har inte rollerna som är nödvändiga för att använda `{0}`-kommandot.",
+        "nsfw": "`{0}`-kommandot kan bara användas i NSFW-kanaler. {:furry.really:}\nhttps://support.discord.com/hc/article_attachments/360007795191/2_.jpg",
+        "permission": "Du har inte behörighet att använda `{0}`-kommandot. {:furry.really:}",
+        "clientPermissions": {
+            "single": "Jag behöver `{1}`-behörighet för att `{0}`-kommandot ska funka.",
+            "multiple": "Jag behöver följande behörigheter för att `{0}`-kommandot ska funka: {1}"
+        },
+        "throttling": {
+            "normal": [
+                "Du kan inte använda `{0}`-kommandot igen under {1}.",
+                "Hallå där! Var god vänta {0} till för du använder `{1}` igen.",
+                "Jag är utmattad. Var god vänta {1} före du använder `{0}` igen.",
+                "Nä helsike. Nog börjar bli trött. Ge mig {1} före du använder `{0}` igen."
+            ],
+            "nsfw": "Du kan inte använda `{0}`-kommandot igen under {1}.\n**Om du skulle vilja förkorta den här väntetiden under dem 12 timmarna härnäst kan du rösta på roboten gratis här: {2}.\nOm du skulle vilja förkorta den här väntetiden permanent kan du donera här: {3}.",
+            "premium": "`{0}` en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
+            "vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5}.",
+            "premium&vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
+        }
+    },
+
+    "error": {
+        "generic": "Hoppsan! Det verkar som ett fel uppstod! Försök igen om några minuter.",
+        "known": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas.",
+        "friendly": "Ett fel uppstod medans det här kommandot utfördes:\n{0}\nDu borde aldrig få ett sådant här fel <:TFRNickConfused:655543877142577179>\nVi har blivit informerade och det här problemet bör bli åtgärdat inom kort.\n[Fundera på att gå med i supportservern för nyheter och uppdateringar]({2} \"owo\") {:furry.fingergun:}"
+    }
+}

--- a/sv/core.json
+++ b/sv/core.json
@@ -17,14 +17,14 @@
         "Nä helsike. Nog börjar bli trött. Ge mig {1} före du använder `{0}` igen."
       ],
       "nsfw": "Du kan inte använda `{0}`-kommandot igen under {1}.\n**Om du skulle vilja förkorta den här väntetiden under dem 12 timmarna härnäst kan du rösta på roboten gratis här: {2}.\nOm du skulle vilja förkorta den här väntetiden permanent kan du donera här: {3}.",
-      "premium": "`{0}` en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
+      "premium": "`{0}` har en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
       "vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5}.",
       "premium_vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
     }
   },
   "error": {
     "generic": "Hoppsan! Det verkar som ett fel uppstod! Försök igen om några minuter.",
-    "known": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas.",
+    "known": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklarna känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas.",
     "friendly": "Ett fel uppstod medans det här kommandot utfördes:\n{0}\nDu borde aldrig få ett sådant här fel <:TFRNickConfused:655543877142577179>\nVi har blivit informerade och det här problemet bör bli åtgärdat inom kort.\n[Fundera på att gå med i supportservern för nyheter och uppdateringar]({2} \"owo\") {:furry.fingergun:}"
   }
 }

--- a/sv/core.json
+++ b/sv/core.json
@@ -1,31 +1,30 @@
 {
-    "blocked": {
-        "guild": "`{0}`-kommandot måste användas i en server.",
-        "premium": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
-        "role": "Du har inte dem nödvändiga rollerna för att använda `{0}`-kommandot.",
-        "nsfw": "`{0}`-kommandot kan bara användas i NSFW-kanaler. {:furry.really:}\nhttps://support.discord.com/hc/article_attachments/360007795191/2_.jpg",
-        "permission": "Du har inte behörighet att använda `{0}`-kommandot. {:furry.really:}",
-        "clientPermissions": {
-            "single": "Jag behöver `{1}`-behörigheten för att `{0}`-kommandot ska funka.",
-            "multiple": "Jag behöver följande behörigheter för att `{0}`-kommandot ska funka: {1}"
-        },
-        "throttling": {
-            "normal": [
-                "Du kan inte använda `{0}`-kommandot igen under {1}.",
-                "Hallå där! Var god vänta {0} till för du använder `{1}` igen.",
-                "Jag är utmattad. Var god vänta {1} före du använder `{0}` igen.",
-                "Nä helsike. Nog börjar bli trött. Ge mig {1} före du använder `{0}` igen."
-            ],
-            "nsfw": "Du kan inte använda `{0}`-kommandot igen under {1}.\n**Om du skulle vilja förkorta den här väntetiden under dem 12 timmarna härnäst kan du rösta på roboten gratis här: {2}.\nOm du skulle vilja förkorta den här väntetiden permanent kan du donera här: {3}.",
-            "premium": "`{0}` en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
-            "vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5}.",
-            "premium_vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
-        }
+  "blocked": {
+    "guild": "`{0}`-kommandot måste användas i en server.",
+    "premium": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
+    "role": "Du har inte dem nödvändiga rollerna för att använda `{0}`-kommandot.",
+    "nsfw": "`{0}`-kommandot kan bara användas i NSFW-kanaler. {:furry.really:}\nhttps://support.discord.com/hc/article_attachments/360007795191/2_.jpg",
+    "permission": "Du har inte behörighet att använda `{0}`-kommandot. {:furry.really:}",
+    "clientPermissions": {
+      "single": "Jag behöver `{1}`-behörigheten för att `{0}`-kommandot ska funka.",
+      "multiple": "Jag behöver följande behörigheter för att `{0}`-kommandot ska funka: {1}"
     },
-
-    "error": {
-        "generic": "Hoppsan! Det verkar som ett fel uppstod! Försök igen om några minuter.",
-        "known": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas.",
-        "friendly": "Ett fel uppstod medans det här kommandot utfördes:\n{0}\nDu borde aldrig få ett sådant här fel <:TFRNickConfused:655543877142577179>\nVi har blivit informerade och det här problemet bör bli åtgärdat inom kort.\n[Fundera på att gå med i supportservern för nyheter och uppdateringar]({2} \"owo\") {:furry.fingergun:}"
+    "throttling": {
+      "normal": [
+        "Du kan inte använda `{0}`-kommandot igen under {1}.",
+        "Hallå där! Var god vänta {0} till för du använder `{1}` igen.",
+        "Jag är utmattad. Var god vänta {1} före du använder `{0}` igen.",
+        "Nä helsike. Nog börjar bli trött. Ge mig {1} före du använder `{0}` igen."
+      ],
+      "nsfw": "Du kan inte använda `{0}`-kommandot igen under {1}.\n**Om du skulle vilja förkorta den här väntetiden under dem 12 timmarna härnäst kan du rösta på roboten gratis här: {2}.\nOm du skulle vilja förkorta den här väntetiden permanent kan du donera här: {3}.",
+      "premium": "`{0}` en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
+      "vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5}.",
+      "premium_vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
     }
+  },
+  "error": {
+    "generic": "Hoppsan! Det verkar som ett fel uppstod! Försök igen om några minuter.",
+    "known": "Åh nej, det verkar som ett fel uppstod medans den här bilden hämtades.\n```javascript\n{0}: {1}\n```\nOroa dig inte över detta! Dessa fel händer väldigt sällan och utvecklargruppen känner till dem.\nDet bästa du kan göra är att återkomma om några minuter så kommer felen inte att återupprepas.",
+    "friendly": "Ett fel uppstod medans det här kommandot utfördes:\n{0}\nDu borde aldrig få ett sådant här fel <:TFRNickConfused:655543877142577179>\nVi har blivit informerade och det här problemet bör bli åtgärdat inom kort.\n[Fundera på att gå med i supportservern för nyheter och uppdateringar]({2} \"owo\") {:furry.fingergun:}"
+  }
 }

--- a/sv/core.json
+++ b/sv/core.json
@@ -2,11 +2,11 @@
     "blocked": {
         "guild": "`{0}`-kommandot måste användas i en server.",
         "premium": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
-        "role": "Du har inte rollerna som är nödvändiga för att använda `{0}`-kommandot.",
+        "role": "Du har inte dem nödvändiga rollerna för att använda `{0}`-kommandot.",
         "nsfw": "`{0}`-kommandot kan bara användas i NSFW-kanaler. {:furry.really:}\nhttps://support.discord.com/hc/article_attachments/360007795191/2_.jpg",
         "permission": "Du har inte behörighet att använda `{0}`-kommandot. {:furry.really:}",
         "clientPermissions": {
-            "single": "Jag behöver `{1}`-behörighet för att `{0}`-kommandot ska funka.",
+            "single": "Jag behöver `{1}`-behörigheten för att `{0}`-kommandot ska funka.",
             "multiple": "Jag behöver följande behörigheter för att `{0}`-kommandot ska funka: {1}"
         },
         "throttling": {

--- a/sv/core.json
+++ b/sv/core.json
@@ -1,9 +1,8 @@
 {
     "blocked": {
-        "guildOnly": "`{0}`-kommandot måste användas i en server.",
-        "premiumOnly": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
-        "supportServerOnly": "`{0}`-kommandot kan bara användas i supportservern. {:furry.really:}",
-        "hasOne": "Du har inte rollerna som är nödvändiga för att använda `{0}`-kommandot.",
+        "guild": "`{0}`-kommandot måste användas i en server.",
+        "premium": "`{0}`-kommandot kan bara användas av premiumanvändare. Du kan skaffa premium på https://paw.bot/donate",
+        "role": "Du har inte rollerna som är nödvändiga för att använda `{0}`-kommandot.",
         "nsfw": "`{0}`-kommandot kan bara användas i NSFW-kanaler. {:furry.really:}\nhttps://support.discord.com/hc/article_attachments/360007795191/2_.jpg",
         "permission": "Du har inte behörighet att använda `{0}`-kommandot. {:furry.really:}",
         "clientPermissions": {
@@ -20,7 +19,7 @@
             "nsfw": "Du kan inte använda `{0}`-kommandot igen under {1}.\n**Om du skulle vilja förkorta den här väntetiden under dem 12 timmarna härnäst kan du rösta på roboten gratis här: {2}.\nOm du skulle vilja förkorta den här väntetiden permanent kan du donera här: {3}.",
             "premium": "`{0}` en kvot på **{2}** varje {3}! Var god vänta {1} längre.\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{4}**/{5}.",
             "vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5}.",
-            "premium&vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
+            "premium_vote": "`{0}` har en kvot på **{2}** varje **{3}**! Var god vänta {1} längre.\n[Rösta](https://top.gg/bot/663823539672973353/vote \"Rösta på Paw Bot\") för en temporär kvot på **{4}**/{5} eller\nBli en [Patron](https://www.patreon.com/JustAPaw \"Bli en Patron\") för en permanent kvot på **{6}**/{7}."
         }
     },
 

--- a/sv/features.json
+++ b/sv/features.json
@@ -1,0 +1,19 @@
+{
+    "lottery": {
+        "disabled": "Lotteriet är förnuvarande avslaget.",
+        "banned": "Du är för nuvarande avstängd från lotterier.",
+        "active": "Ett lotteri äger rum just nu.",
+        "insufficient": {
+            "single": "Du har inte nog med pengar för att köpa en lott.",
+            "multiple": "Du har inte råd med så många lotter."
+        },
+        "maximum": {
+            "normal": "1.000 lotter är maxantalet.\nBli en premiumanvändare genom att donera på Patreon och få ett maxantal om 100.000 lotter: <{0}>",
+            "premium": "100.000 lotter är maxantalet för premiumanvändare."
+        },
+        "won": {
+            "normal": "{0} vann just **{1}** poäng med **{2}** lotter använda!",
+            "voted": "{0} har röstat och vann just **{1}** (**{3}x**) poäng med **{2}** lotter använda!"
+        }
+    }
+}

--- a/sv/features.json
+++ b/sv/features.json
@@ -1,6 +1,6 @@
 {
     "lottery": {
-        "disabled": "Lotteriet är förnuvarande avslaget.",
+        "disabled": "Lotteriet är förnuvarande stängt.",
         "banned": "Du är för nuvarande avstängd från lotterier.",
         "active": "Ett lotteri äger rum just nu.",
         "insufficient": {

--- a/sv/features.json
+++ b/sv/features.json
@@ -1,19 +1,19 @@
 {
-    "lottery": {
-        "disabled": "Lotteriet är förnuvarande stängt.",
-        "banned": "Du är för nuvarande avstängd från lotterier.",
-        "active": "Ett lotteri äger rum just nu.",
-        "insufficient": {
-            "single": "Du har inte nog med pengar för att köpa en lott.",
-            "multiple": "Du har inte råd med så många lotter."
-        },
-        "maximum": {
-            "normal": "1.000 lotter är maxantalet.\nBli en premiumanvändare genom att donera på Patreon och få ett maxantal om 100.000 lotter: <{0}>",
-            "premium": "100.000 lotter är maxantalet för premiumanvändare."
-        },
-        "won": {
-            "normal": "{0} vann just **{1}** poäng med **{2}** lotter använda!",
-            "voted": "{0} har röstat och vann just **{1}** (**{3}x**) poäng med **{2}** lotter använda!"
-        }
+  "lottery": {
+    "disabled": "Lotteriet är förnuvarande stängt.",
+    "banned": "Du är för nuvarande avstängd från lotterier.",
+    "active": "Ett lotteri äger rum just nu.",
+    "insufficient": {
+      "single": "Du har inte nog med pengar för att köpa en lott.",
+      "multiple": "Du har inte råd med så många lotter."
+    },
+    "maximum": {
+      "normal": "1.000 lotter är maxantalet.\nBli en premiumanvändare genom att donera på Patreon och få ett maxantal om 100.000 lotter: <{0}>",
+      "premium": "100.000 lotter är maxantalet för premiumanvändare."
+    },
+    "won": {
+      "normal": "{0} vann just **{1}** poäng med **{2}** lotter använda!",
+      "voted": "{0} har röstat och vann just **{1}** (**{3}x**) poäng med **{2}** lotter använda!"
     }
+  }
 }

--- a/sv/words.json
+++ b/sv/words.json
@@ -1,4 +1,4 @@
 {
-    "leaderboard": "Topplista",
-    "default": "standard"
+  "leaderboard": "Topplista",
+  "default": "standard"
 }

--- a/sv/words.json
+++ b/sv/words.json
@@ -1,0 +1,4 @@
+{
+    "leaderboard": "Topplista",
+    "default": "standard"
+}


### PR DESCRIPTION
## Type

<!--
    Check all that matches what you've modified
    [ ] = no
    [x] = yes
-->

- [ ] Edit
- [ ] English Edit
- [x] Full Audit
- [ ] Incomplete Audit
- [ ] Update Outdated Translation(s)
- [ ] Enhance Translation(s)

## Information
<!-- Please describe in full what you have done -->
This PR provides complete Swedish-language translations.

I’m aware that some of the wording is a bit awkward if you’re a native Swedish speaker, and I’m referring to the translations for the user-to-user interaction commands (`hug`, `flop`, `cuddle`, etc.) here in particular. I couldn’t map the possessive forms of “&lt;USER&gt;” to their Swedish counterparts cleanly, and so I decided to simply route around it.

(`"{0} boops {1}'s wet snoot gently."` for `John` and `Jane` would be translated as `"John boppar Janes nos försiktigt"`, but this can’t be generalised to *all* names since names that actually end with “s” don’t need to have another “s” appended to denote its possessive form. Therefore the actually provided translation is `"{0} boppar försiktigt {1} på hens våta nos."`)

Arguably this was an unnecessary compromise (“&lt;USER&gt;'s” is not always correct in English either) and I’m open to revising these translations.