### PR TITLE
Fix Duplicated Template Parameter in EN Localisation

### DIFF
--- a/en/commands.json
+++ b/en/commands.json
@@ -271,7 +271,7 @@
     "title": [
       "{0} falls directly into {1}'s lap with a loud fwooosh.",
       "{1} gets their lap stolen by {0}. Finders keepers, I guess?",
-      "{0} jumps on to {0} and squishes them.",
+      "{0} jumps on to {1} and squishes them.",
       "{1} gets squished by {0}'s fat ass.",
       "{0} makes themself comfy and lands on {1}.",
       "{0} falls like a feather on to {1}.",

--- a/es/commands.json
+++ b/es/commands.json
@@ -271,7 +271,7 @@
     "title": [
       "{0} cae directamente en el regazo de {1} con un fuerte fwooosh.",
       "{0} le roba la vuelta a {1}. ¿Los encargados de los buscadores, supongo?",
-      "{0} salta sobre {0} y los aplasta.",
+      "{0} salta sobre {1} y los aplasta.",
       "{1} es aplastado por el culo gordo de {0}.",
       "{0} se pone cómodo y aterriza en {1}.",
       "{0} cae como una pluma sobre {1}.",

--- a/fr/commands.json
+++ b/fr/commands.json
@@ -271,7 +271,7 @@
     "title": [
       "{0} tombe directement sur les jambes de {1} bruyamment.",
       "{1} se fait voler son tour par {0}. Qui va à la chasse perd sa place, je suppose?",
-      "{0} saute sur {0} et les écrase.",
+      "{0} saute sur {1} et les écrase.",
       "{1} se fait écraser par les énormes fesses de {0}.",
       "{0} se met à l'aise et atterit sur {1}.",
       "{0} tombe comme une plume sur {1}.",

--- a/sv/commands.json
+++ b/sv/commands.json
@@ -76,7 +76,6 @@
     "donations": "**Totala donationer**: £{0}\n**Totala donatorer**: {1} personer\nSnälla överväg att donera till NHS på JustGiving för att stödja folk i nöd i dessa prövande tider [här]({2} \"akut vädjan angående COVID-19\")",
     "format": "**Totalt**: {0}\n**Idag**: {1}"
   },
-  "e926": {},
   "e6": {
     "searching": "Söker {:loading:}",
     "none": "Hittade inga resultat med dem angivna etiketterna.",
@@ -104,13 +103,9 @@
   "fursuit": {
     "title": "🐾 Här är din pälsdräktsbild!"
   },
-  "lenny": {},
-  "owoify": {},
-  "proxy": {},
   "shibe": {
     "title": "🐶 Här är din shibabild!"
   },
-  "vote-out": {},
   "daily": {
     "success": "{:check:} Du har tagit emot din dagliga poängkvot á **{0}** poäng!\nKom tillbaka imorgon vid **0:00 UTC** för **10.000** extra poäng! (Max 50.000 poäng, kombosar återställs efter en missad dag)",
     "failed": "Hoppsan! Det verkar som du redan har tagit emot dina dagliga poäng. Återkom efter {0}.\n"
@@ -161,8 +156,6 @@
       "vote": "Hur man röstar"
     }
   },
-  "purge": {},
-  "qotd": {},
   "role": {
     "roleabove": "Den här rollen är ovanför din roll och kan varken läggas till eller tas bort.",
     "userabove": "{0} har en roll ovanför dig och kan inte redigeras.",
@@ -246,12 +239,6 @@
       "Ojsan. Den är så stor att jag kan se min spegelbild i den."
     ]
   },
-  "e621": {},
-  "hentai": {},
-  "hooman": {},
-  "meme": {},
-  "murrsuit": {},
-  "yaoi": {},
   "yiff": {
     "title": [
       "Jag slår vad om att den här killen har en söt rumpa.",
@@ -291,7 +278,6 @@
       "{0} blir uttröttad och bestämmer sig för att ta sig en tupplur på {1}."
     ]
   },
-  "fuck": {},
   "hold": {
     "title": [
       "{0} håller kärleksfullt i {1} i sin mjuka, varsamma famn.",
@@ -393,7 +379,6 @@
       "none": "Satte framgångsrikt QoTD-aviseringsrollen till `none`."
     }
   },
-  "toggle-unknown-command-responses": {},
   "welcome-channel": {
     "info": "Den nuvarande välkommstkanalen är **{0}**.",
     "none": "Ingen välkommstkanal har specificerats.",


### PR DESCRIPTION
## Type

<!--
    Check all that matches what you've modified
    [ ] = no
    [x] = yes
-->

- [x] Edit
- [x] English Edit
- [ ] Full Audit
- [ ] Incomplete Audit
- [ ] Update Outdated Translation(s)
- [ ] Enhance Translation(s)

## Information
<!-- Please describe in full what you have done -->

The string `"{0} jumps on to {0} and squishes them."` on line 274 duplicates the `{0}` template parameter, rendering the name of the command caller twice. This corrects the second parameter to be `1` (the target user).

This PR fixes the error in the English localisation, but it exists in all translations except for Swedish (it was either fixed or the template parameters weren’t copied “correctly”). ~~However, I’m not confident enough to touch the French and Spanish translations and therefore I’ve opted to leave those as-is, deferring it to those who actually speak the respective languages (issue #8)~~.

(This PR now closes #8.)